### PR TITLE
added container.html template

### DIFF
--- a/travel2change/moderations/views.py
+++ b/travel2change/moderations/views.py
@@ -48,7 +48,7 @@ class ActivityDisapprovalView(StaffUserOnlyMixin, DeleteView):
     success_url = reverse_lazy("moderations:queue")
 
     def get_object(self):
-        return get_object_or_404(Activity, slug=self.kwargs['slug'])
+        return get_object_or_404(Activity, pk=self.kwargs['pk'])
     
     def delete(self, request, *args, **kwargs):
         # Notify users about disapproval, then delete object

--- a/travel2change/static/css/main.css
+++ b/travel2change/static/css/main.css
@@ -19,6 +19,15 @@
     margin-bottom: 2rem;
 }
 
+#content-wrapper {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+}
+#content-wrapper main {
+    flex: 1;
+}
+
 /* DJANGO MESSAGES */
 
 .messages {

--- a/travel2change/static/css/main.css
+++ b/travel2change/static/css/main.css
@@ -14,7 +14,7 @@
     height: 100vh;
 }
 
-.container main {
+#main .container {
     margin-top: 2rem;
     margin-bottom: 2rem;
 }

--- a/travel2change/templates/400.html
+++ b/travel2change/templates/400.html
@@ -1,12 +1,10 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 
 {% block title %}400 - Bad Request{% endblock title %}
 
 {% block content %}
-	<div class="container">
-        <h1>400 - Bad Request</h1>
-        <p>
-            Sorry, we do not understand what you are doing.
-        </p>
-	</div>
+<h1>400 - Bad Request</h1>
+<p>
+    Sorry, we do not understand what you are doing.
+</p>
 {% endblock content %}

--- a/travel2change/templates/403.html
+++ b/travel2change/templates/403.html
@@ -1,18 +1,16 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 
 {% block title %}403 - Permission Denied{% endblock title %}
 
 {% block content %}
-	<div class="container">
-        <h1>You do not have the permissions to view.</h1>
-        {% if exception %}
-        <p>
-            {{ exception }}
-        </p>
-        {% else %}
-        <p>
-            There is not reason for you to view this page. 😅
-        </p>
-        {% endif %}
-	</div>
+    <h1>You do not have the permissions to view.</h1>
+    {% if exception %}
+    <p>
+        {{ exception }}
+    </p>
+    {% else %}
+    <p>
+        There is not reason for you to view this page. 😅
+    </p>
+    {% endif %}
 {% endblock content %}

--- a/travel2change/templates/403_csrf.html
+++ b/travel2change/templates/403_csrf.html
@@ -1,12 +1,10 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 
 {% block title %}403 - Permission Denied{% endblock title %}
 
 {% block content %}
-	<div class="container">
-        <h1>403 Forbidden</h1>
-        <p>
-            CSRF verification failed. Request aborted.
-        </p>
-	</div>
+    <h1>403 Forbidden</h1>
+    <p>
+        CSRF verification failed. Request aborted.
+    </p>
 {% endblock content %}

--- a/travel2change/templates/404.html
+++ b/travel2change/templates/404.html
@@ -1,9 +1,8 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 
 {% block title %}404 - Page Not Found{% endblock title %}
 
 {% block content %}
-	<div class="container">
         <h1>Oh no!</h1>
         <p>You are stuck in a middle of no-where. You thought you were going to the right direction, but now you have to make a decision.</p>
         <ol>
@@ -11,5 +10,4 @@
             <li>Try to figure out what went wrong?</li>
             <li>Report this to the heavens</li>
         </ol>
-	</div>
 {% endblock content %}

--- a/travel2change/templates/500.html
+++ b/travel2change/templates/500.html
@@ -1,12 +1,10 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 
 {% block title %}500 - Server Error{% endblock title %}
 
 {% block content %}
-	<div class="container">
         <h1>500 - Server Error</h1>
         <p>
             Uh oh. Something went wrong... That's all we know.
         </p>
-	</div>
 {% endblock content %}

--- a/travel2change/templates/account/base.html
+++ b/travel2change/templates/account/base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load sekizai_tags cache staticfiles %}
-{% block content %}
+{% block container %}
 {% addtoblock "css" %}
     <link rel="stylesheet" href="{% static 'css/accounts/accounts.css' %}">
 {% endaddtoblock %}
@@ -11,4 +11,4 @@
     </div>
 </div>
 
-{% endblock content %}
+{% endblock container %}

--- a/travel2change/templates/account/email.html
+++ b/travel2change/templates/account/email.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags %}
 {% block title %}{% trans "Modify Email(s)" %}{% endblock %}
 {% block content %}

--- a/travel2change/templates/account/password_change.html
+++ b/travel2change/templates/account/password_change.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags %}
 {% block title %}{% trans "Change Password" %}{% endblock %}
 {% block content %}

--- a/travel2change/templates/activities/activity_browse.html
+++ b/travel2change/templates/activities/activity_browse.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load sekizai_tags cache staticfiles %}
 {% block title %}Activity Browse{% endblock title %}
 {% block styles %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.7/dist/css/bootstrap-select.min.css">

--- a/travel2change/templates/activities/activity_delete.html
+++ b/travel2change/templates/activities/activity_delete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Delete Activity{% endblock title %}
 {% block content %}
 <div class="row">

--- a/travel2change/templates/activities/activity_detail.html
+++ b/travel2change/templates/activities/activity_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load cms_tags google_maps_api crispy_forms_tags social_share cache staticfiles %}
 {% block title %}{{ activity.title }} - travel2change{% endblock title %}
 {% block content %}

--- a/travel2change/templates/activities/activity_done.html
+++ b/travel2change/templates/activities/activity_done.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load sekizai_tags cache staticfiles %}
 {% block title %}You have successfully submitted your activity.{% endblock title %}
 {% block content %}
 <h1>You have successfully submitted your activity</h1>

--- a/travel2change/templates/activities/activity_review.html
+++ b/travel2change/templates/activities/activity_review.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load sekizai_tags social_share cache staticfiles %}
+{% extends "container.html" %}{% load sekizai_tags social_share cache staticfiles %}
 {% block content %}
     <h1>New comment</h1>
     <form method="POST" class="post-form">{% csrf_token %}

--- a/travel2change/templates/activities/activity_update.html
+++ b/travel2change/templates/activities/activity_update.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Update - {{ activity.title }}{% endblock title %}
 {% block content %}
 <div class="row">

--- a/travel2change/templates/activities/activity_upload.html
+++ b/travel2change/templates/activities/activity_upload.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Edit Photos - {{ activity.title }}{% endblock title %}
 {% block content %}
 {% addtoblock "css" %}

--- a/travel2change/templates/activities/wizard_templates/confirmation.html
+++ b/travel2change/templates/activities/wizard_templates/confirmation.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Confirmation - Activity Creation Wizard{% endblock title %}
 {% block content %}

--- a/travel2change/templates/activities/wizard_templates/default.html
+++ b/travel2change/templates/activities/wizard_templates/default.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Step {{ wizard.steps.step1 }} - Activity Creation Wizard{% endblock title %}
 {% block content %}

--- a/travel2change/templates/activities/wizard_templates/featured_photo.html
+++ b/travel2change/templates/activities/wizard_templates/featured_photo.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Step {{ wizard.steps.step1 }} - Activity Creation Wizard{% endblock title %}
 {% block content %}

--- a/travel2change/templates/activities/wizard_templates/location.html
+++ b/travel2change/templates/activities/wizard_templates/location.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load google_maps_api crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Step {{ wizard.steps.step1 }} - Activity Creation Wizard{% endblock title %}
 {% block content %}

--- a/travel2change/templates/activities/wizard_templates/price_fh.html
+++ b/travel2change/templates/activities/wizard_templates/price_fh.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Step {{ wizard.steps.step1 }} - Activity Creation Wizard{% endblock title %}
 {% block content %}

--- a/travel2change/templates/base.html
+++ b/travel2change/templates/base.html
@@ -37,11 +37,11 @@
     </head>
     <body>
         {% cms_toolbar %}
-        {% include 'partials/navigation.html' %}
-        {% include 'partials/messages.html' %}
-        {% block jumbo %}
-        {% endblock jumbo %}
+        {% include 'partials/header.html' %}
         <main id="main">
+            {% include 'partials/messages.html' %}
+            {% block jumbo %}
+            {% endblock jumbo %}
             {% block container %}
             {% endblock container %}
         </main>

--- a/travel2change/templates/base.html
+++ b/travel2change/templates/base.html
@@ -41,12 +41,10 @@
         {% include 'partials/messages.html' %}
         {% block jumbo %}
         {% endblock jumbo %}
-        <div class="container p-3">
-            <main class="content">
-                {% block content %}
-                {% endblock content %}
-            </main>
-        </div>
+        <main id="main">
+            {% block container %}
+            {% endblock container %}
+        </main>
         <footer class="py-5 bg-light">
             <div class="container">
                 <p class="m-0 text-center text-black">Copyright &copy; travel2change 2019</p>

--- a/travel2change/templates/base.html
+++ b/travel2change/templates/base.html
@@ -37,22 +37,24 @@
     </head>
     <body>
         {% cms_toolbar %}
-        {% include 'partials/header.html' %}
-        <main id="main">
+        <div id="content-wrapper">
+            {% include 'partials/header.html' %}
             {% include 'partials/messages.html' %}
-            {% block jumbo %}
-            {% endblock jumbo %}
-            {% block container %}
-            {% endblock container %}
-        </main>
-        <footer class="py-5 bg-light">
-            <div class="container">
-                <p class="m-0 text-center text-black">Copyright &copy; travel2change 2019</p>
-            </div>
-            <!-- /.container -->
-        </footer>
-        {% render_block "js" %}
-        {% block scripts %}{% endblock scripts %}
+            <main id="main">
+                {% block jumbo %}
+                {% endblock jumbo %}
+                {% block container %}
+                {% endblock container %}
+            </main>
+            <footer class="py-5 bg-light">
+                <div class="container">
+                    <p class="m-0 text-center text-black">Copyright &copy; travel2change 2019</p>
+                </div>
+                <!-- /.container -->
+            </footer>
+            {% render_block "js" %}
+            {% block scripts %}{% endblock scripts %}
+        </div>
         {% addtoblock "js" %}
             <script
                 src="https://code.jquery.com/jquery-3.3.1.min.js"

--- a/travel2change/templates/container.html
+++ b/travel2change/templates/container.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block container %}
+<div class="container">{% block content %}{% endblock %}</div>
+{% endblock %}

--- a/travel2change/templates/favorites/favorites_list.html
+++ b/travel2change/templates/favorites/favorites_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load humanize sekizai_tags thumbnail cache staticfiles %}
+{% extends "container.html" %}{% load humanize sekizai_tags thumbnail cache staticfiles %}
 {% block title %}favorites - {{ user.get_full_name }}{% endblock title %}
 {% block styles %}
 {% endblock styles %}

--- a/travel2change/templates/fullwidth.html
+++ b/travel2change/templates/fullwidth.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load cms_tags %}
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}

--- a/travel2change/templates/home.html
+++ b/travel2change/templates/home.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "container.html" %}
 {% load cms_tags staticfiles %}
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 {% block styles %}

--- a/travel2change/templates/moderations/moderation_approval.html
+++ b/travel2change/templates/moderations/moderation_approval.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Approve {{ activity.title }}{% endblock title %}
 {% block content %}
 <div class="row">

--- a/travel2change/templates/moderations/moderation_disapproval.html
+++ b/travel2change/templates/moderations/moderation_disapproval.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load crispy_forms_tags sekizai_tags cache staticfiles %}
 {% block title %}Disapprove {{ activity.title }}{% endblock title %}
 {% block content %}
 <div class="row">

--- a/travel2change/templates/moderations/moderation_queue.html
+++ b/travel2change/templates/moderations/moderation_queue.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load sekizai_tags thumbnail cache staticfiles %}
+{% extends "container.html" %}{% load sekizai_tags thumbnail cache staticfiles %}
 {% block title %}Activity Moderation Queue{% endblock title %}
 {% block styles %}
 {% endblock styles %}

--- a/travel2change/templates/partials/header.html
+++ b/travel2change/templates/partials/header.html
@@ -1,5 +1,5 @@
 {% load i18n menu_tags %}
-<nav class="navbar navbar-expand-lg navbar-light bg-light t2c-navbar">
+<header class="navbar navbar-expand-lg navbar-light bg-light t2c-navbar">
   <div class="container">
     <a class="navbar-brand" href="/">travel2change</a>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
@@ -7,7 +7,7 @@
       aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="collapse navbar-collapse" id="navbarResponsive">
+    <nav class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav mr-auto">
         {% show_menu 0 100 100 100 %}
       </ul>
@@ -39,6 +39,6 @@
         </li>
         {% endif %}
       </ul>
-    </div>
+    </nav>
   </div>
-</nav>
+</header>

--- a/travel2change/templates/users/host_activities_dashboard.html
+++ b/travel2change/templates/users/host_activities_dashboard.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags %}
 {% block title %}{% trans "Modify Account" %}{% endblock %}
 {% block content %}

--- a/travel2change/templates/users/host_activities_list.html
+++ b/travel2change/templates/users/host_activities_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
 {% block title %}{{ host.name }}'s Activities{% endblock title %}
 {% block jumbo %}
 <div class="jumbotron jumbotron-fluid">

--- a/travel2change/templates/users/host_detail.html
+++ b/travel2change/templates/users/host_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
 {% block title %}{{ host.name }}{% endblock title %}
 {% block styles %}
 <link rel="stylesheet" href="{% static 'css/users/profile.css' %}">

--- a/travel2change/templates/users/host_reviews_list.html
+++ b/travel2change/templates/users/host_reviews_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
+{% extends "container.html" %}{% load humanize thumbnail sekizai_tags cache staticfiles %}
 {% block title %}Reviews about {{ host.name }}{% endblock title %}
 {% block styles %}
 <link rel="stylesheet" href="{% static 'css/star-ratings/star-rating.min.css' %}" media="all" type="text/css" />

--- a/travel2change/templates/users/host_update.html
+++ b/travel2change/templates/users/host_update.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags %}
 {% block title %}{% trans "Edit Host Profile" %}{% endblock %}
 {% block content %}

--- a/travel2change/templates/users/user_reviews.html
+++ b/travel2change/templates/users/user_reviews.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags humanize staticfiles %}
 {% block title %}{% trans "Your Reviews" %}{% endblock %}
 {% block styles %}

--- a/travel2change/templates/users/user_update.html
+++ b/travel2change/templates/users/user_update.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "container.html" %}
 {% load i18n crispy_forms_tags %}
 {% block title %}{% trans "Modify Account" %}{% endblock %}
 {% block content %}


### PR DESCRIPTION
Added a new `container.html` template that inherits from `base.html` and has the content block wrapped around a container div. This is so if a template needs to have a container wrapped around it, it could inherit (extends) from container.html instead of base.html. 

**reason:** there are some cases where content should not be always wrapped around a container. For instance, the widget may utilize a fluid jumbotron but has text content wrapped around the container (just like in travel2change.org)